### PR TITLE
Fix bad relation name

### DIFF
--- a/ontologies/context.json
+++ b/ontologies/context.json
@@ -20,9 +20,6 @@
     "dfc-b:referencedBy":{
       "@type":"@id"
     },
-    "dfc-b:offeredThroug":{
-      "@type":"@id"
-    },
     "dfc-b:offeres":{
       "@type":"@id"
     },


### PR DESCRIPTION
We should remove the bad `offeredThroug` relation (missing an ending "h").

The correct `dfc-b:offeredThrough` relation is already present further in the file.