### PR TITLE
upgrade context.json to match ontology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   refersTo.
 -   uses.
 
+## [1.8.2] - 2023-10-03
+
+### Fixed
+upgrade context.json to match ontology
+- replace dfc-b:offeres by dfc-b:offers
+- add dfc-b:offersTo as uri predicate
+- add dfc-b:affiliatedB as uri predicate
+- add dfc-b:orders as uri predicate
+- add dfc-b:orderedBy as uri predicate
+- add dfc-b:hasPart as uri predicate
+- add dfc-b:partOf as uri predicate
+- add dfc-b:belongsTo as uri predicate
+- add dfc-b:selects as uri predicate
+- add dfc-b:concerns as uri predicate
+- add dfc-b:uses as uri predicate
+- add dfc-b:hasOption as uri predicate
+- add dfc-b:hostedAt as uri predicate
+- add dfc-b:lists as uri predicate
+- add dfc-b:listedIn as uri predicate
+- add dfc-b:objectOf as uri predicate
+- add dfc-b:managedBy as uri predicate
+- add dfc-b:coordinatedBy as uri predicate
+- add dfc-b:hasObject as uri predicate
+- add dfc-b:localizedBy as uri predicate
+- add dfc-b:constitutes as uri predicate
+- add dfc-b:identifiedBy as uri predicate
+- add dfc-b:storedIn as uri predicate
+
 ## [1.8.0] - 2023-10-03
 
 ### Added

--- a/context.json
+++ b/context.json
@@ -32,7 +32,13 @@
     "dfc-b:referencedBy":{
       "@type":"@id"
     },
-    "dfc-b:offeres":{
+    "dfc-b:offers":{
+      "@type":"@id"
+    },
+    "dfc-b:offersTo":{
+      "@type":"@id"
+    },
+    "dfc-b:offeredThrough":{
       "@type":"@id"
     },
     "dfc-b:supplies":{
@@ -44,13 +50,61 @@
     "dfc-b:affiliates":{
       "@type":"@id"
     },
+    "dfc-b:affiliatedBy":{
+      "@type":"@id"
+    },
+    "dfc-b:orders":{
+      "@type":"@id"
+    },
+    "dfc-b:orderedBy":{
+      "@type":"@id"
+    },
+    "dfc-b:hasPart":{
+      "@type":"@id"
+    },
+    "dfc-b:partOf":{
+      "@type":"@id"
+    },
+    "dfc-b:belongsTo":{
+      "@type":"@id"
+    },
+    "dfc-b:selects":{
+      "@type":"@id"
+    },
+    "dfc-b:concerns":{
+      "@type":"@id"
+    },
+    "dfc-b:uses":{
+      "@type":"@id"
+    },
+    "dfc-b:hasOption":{
+      "@type":"@id"
+    },
+    "dfc-b:hostedAt":{
+      "@type":"@id"
+    },
+    "dfc-b:lists":{
+      "@type":"@id"
+    },
+    "dfc-b:listedIn":{
+      "@type":"@id"
+    },
+    "dfc-b:objectOf":{
+      "@type":"@id"
+    },
     "dfc-b:hasCertification":{
       "@type":"@id"
     },
     "dfc-b:manages":{
       "@type":"@id"
     },
-    "dfc-b:offeredThrough":{
+    "dfc-b:managedBy":{
+      "@type":"@id"
+    },
+    "dfc-b:coordinatedBy":{
+      "@type":"@id"
+    },
+    "dfc-b:hasObject":{
       "@type":"@id"
     },
     "dfc-b:hasBrand":{
@@ -69,6 +123,18 @@
       "@type":"@id"
     },
     "dfc-b:hasPhysicalDimension":{
+      "@type":"@id"
+    },
+    "dfc-b:localizedBy":{
+      "@type":"@id"
+    },
+    "dfc-b:constitutes":{
+      "@type":"@id"
+    },
+    "dfc-b:identifiedBy":{
+      "@type":"@id"
+    },
+    "dfc-b:storedIn":{
       "@type":"@id"
     },
     "dfc:owner":{


### PR DESCRIPTION
- replace dfc-b:offeres by dfc-b:offers
- add dfc-b:offersTo as uri predicate
- add dfc-b:affiliatedB as uri predicate
- add dfc-b:orders as uri predicate
- add dfc-b:orderedBy as uri predicate
- add dfc-b:hasPart as uri predicate
- add dfc-b:partOf as uri predicate
- add dfc-b:belongsTo as uri predicate
- add dfc-b:selects as uri predicate
- add dfc-b:concerns as uri predicate
- add dfc-b:uses as uri predicate
- add dfc-b:hasOption as uri predicate
- add dfc-b:hostedAt as uri predicate
- add dfc-b:lists as uri predicate
- add dfc-b:listedIn as uri predicate
- add dfc-b:objectOf as uri predicate
- add dfc-b:managedBy as uri predicate
- add dfc-b:coordinatedBy as uri predicate
- add dfc-b:hasObject as uri predicate
- add dfc-b:localizedBy as uri predicate
- add dfc-b:constitutes as uri predicate
- add dfc-b:identifiedBy as uri predicate
- add dfc-b:storedIn as uri predicate