### PR TITLE
upgrade context.json to match ontology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Brand as a Facet.
 
 [unreleased]: https://github.com/datafoodconsortium/ontology/compare/v1.9.0...master
+[1.9.2]: https://github.com/datafoodconsortium/ontology/compare/v1.9.1...v1.9.2
+[1.9.1]: https://github.com/datafoodconsortium/ontology/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/datafoodconsortium/ontology/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/datafoodconsortium/ontology/compare/v1.7.3...v1.8.0
 [1.7.3]: https://github.com/datafoodconsortium/ontology/compare/v1.7.2...v1.7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,30 +10,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.9.2] - 2023-12-14
 
 ### Fixed
-upgrade context.json to match ontology
-- replace dfc-b:offeres by dfc-b:offers
-- add dfc-b:offersTo as uri predicate
-- add dfc-b:affiliatedB as uri predicate
-- add dfc-b:orders as uri predicate
-- add dfc-b:orderedBy as uri predicate
-- add dfc-b:hasPart as uri predicate
-- add dfc-b:partOf as uri predicate
-- add dfc-b:belongsTo as uri predicate
-- add dfc-b:selects as uri predicate
-- add dfc-b:concerns as uri predicate
-- add dfc-b:uses as uri predicate
-- add dfc-b:hasOption as uri predicate
-- add dfc-b:hostedAt as uri predicate
-- add dfc-b:lists as uri predicate
-- add dfc-b:listedIn as uri predicate
-- add dfc-b:objectOf as uri predicate
-- add dfc-b:managedBy as uri predicate
-- add dfc-b:coordinatedBy as uri predicate
-- add dfc-b:hasObject as uri predicate
-- add dfc-b:localizedBy as uri predicate
-- add dfc-b:constitutes as uri predicate
-- add dfc-b:identifiedBy as uri predicate
-- add dfc-b:storedIn as uri predicate
+- upgrade context.json to match ontology
+    - replace dfc-b:offeres by dfc-b:offers
+    - add dfc-b:offersTo as uri predicate
+    - add dfc-b:affiliatedB as uri predicate
+    - add dfc-b:orders as uri predicate
+    - add dfc-b:orderedBy as uri predicate
+    - add dfc-b:hasPart as uri predicate
+    - add dfc-b:partOf as uri predicate
+    - add dfc-b:belongsTo as uri predicate
+    - add dfc-b:selects as uri predicate
+    - add dfc-b:concerns as uri predicate
+    - add dfc-b:uses as uri predicate
+    - add dfc-b:hasOption as uri predicate
+    - add dfc-b:hostedAt as uri predicate
+    - add dfc-b:lists as uri predicate
+    - add dfc-b:listedIn as uri predicate
+    - add dfc-b:objectOf as uri predicate
+    - add dfc-b:managedBy as uri predicate
+    - add dfc-b:coordinatedBy as uri predicate
+    - add dfc-b:hasObject as uri predicate
+    - add dfc-b:localizedBy as uri predicate
+    - add dfc-b:constitutes as uri predicate
+    - add dfc-b:identifiedBy as uri predicate
+    - add dfc-b:storedIn as uri predicate
 
 
 ## [1.9.1] - 2023-11-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   refersTo.
 -   uses.
 
+## [1.8.2] - 2023-10-03
+
+### Fixed
+upgrade context.json to match ontology
+- replace dfc-b:offeres by dfc-b:offers
+- add dfc-b:offersTo as uri predicate
+- add dfc-b:affiliatedB as uri predicate
+- add dfc-b:orders as uri predicate
+- add dfc-b:orderedBy as uri predicate
+- add dfc-b:hasPart as uri predicate
+- add dfc-b:partOf as uri predicate
+- add dfc-b:belongsTo as uri predicate
+- add dfc-b:selects as uri predicate
+- add dfc-b:concerns as uri predicate
+- add dfc-b:uses as uri predicate
+- add dfc-b:hasOption as uri predicate
+- add dfc-b:hostedAt as uri predicate
+- add dfc-b:lists as uri predicate
+- add dfc-b:listedIn as uri predicate
+- add dfc-b:objectOf as uri predicate
+- add dfc-b:managedBy as uri predicate
+- add dfc-b:coordinatedBy as uri predicate
+- add dfc-b:hasObject as uri predicate
+- add dfc-b:localizedBy as uri predicate
+- add dfc-b:constitutes as uri predicate
+- add dfc-b:identifiedBy as uri predicate
+- add dfc-b:storedIn as uri predicate
+
+
 ## [1.8.0] - 2023-10-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.2] - 2023-12-14
+
+### Fixed
+upgrade context.json to match ontology
+- replace dfc-b:offeres by dfc-b:offers
+- add dfc-b:offersTo as uri predicate
+- add dfc-b:affiliatedB as uri predicate
+- add dfc-b:orders as uri predicate
+- add dfc-b:orderedBy as uri predicate
+- add dfc-b:hasPart as uri predicate
+- add dfc-b:partOf as uri predicate
+- add dfc-b:belongsTo as uri predicate
+- add dfc-b:selects as uri predicate
+- add dfc-b:concerns as uri predicate
+- add dfc-b:uses as uri predicate
+- add dfc-b:hasOption as uri predicate
+- add dfc-b:hostedAt as uri predicate
+- add dfc-b:lists as uri predicate
+- add dfc-b:listedIn as uri predicate
+- add dfc-b:objectOf as uri predicate
+- add dfc-b:managedBy as uri predicate
+- add dfc-b:coordinatedBy as uri predicate
+- add dfc-b:hasObject as uri predicate
+- add dfc-b:localizedBy as uri predicate
+- add dfc-b:constitutes as uri predicate
+- add dfc-b:identifiedBy as uri predicate
+- add dfc-b:storedIn as uri predicate
+
+
 ## [1.9.1] - 2023-11-15
 
 ### Added
@@ -88,35 +117,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   refersTo.
 -   uses.
-
-## [1.8.2] - 2023-10-03
-
-### Fixed
-upgrade context.json to match ontology
-- replace dfc-b:offeres by dfc-b:offers
-- add dfc-b:offersTo as uri predicate
-- add dfc-b:affiliatedB as uri predicate
-- add dfc-b:orders as uri predicate
-- add dfc-b:orderedBy as uri predicate
-- add dfc-b:hasPart as uri predicate
-- add dfc-b:partOf as uri predicate
-- add dfc-b:belongsTo as uri predicate
-- add dfc-b:selects as uri predicate
-- add dfc-b:concerns as uri predicate
-- add dfc-b:uses as uri predicate
-- add dfc-b:hasOption as uri predicate
-- add dfc-b:hostedAt as uri predicate
-- add dfc-b:lists as uri predicate
-- add dfc-b:listedIn as uri predicate
-- add dfc-b:objectOf as uri predicate
-- add dfc-b:managedBy as uri predicate
-- add dfc-b:coordinatedBy as uri predicate
-- add dfc-b:hasObject as uri predicate
-- add dfc-b:localizedBy as uri predicate
-- add dfc-b:constitutes as uri predicate
-- add dfc-b:identifiedBy as uri predicate
-- add dfc-b:storedIn as uri predicate
-
 
 ## [1.8.0] - 2023-10-03
 

--- a/context.json
+++ b/context.json
@@ -1,87 +1,153 @@
 {
-   "@context": {
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "skos" : "http://www.w3.org/2004/02/skos/core#",
-    "dfc": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_FullModel.owl#",
-    "dc": "http://purl.org/dc/elements/1.1/#",
-    "dfc-b": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_BusinessOntology.owl#",
-    "dfc-p": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_ProductGlossary.owl#",
-    "dfc-t": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_TechnicalOntology.owl#",
-    "dfc-m": "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/measures.rdf#",
-    "dfc-pt": "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#",
-    "dfc-f": "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/facets.rdf#",
-   "ontosec": "http://www.semanticweb.org/ontologies/2008/11/OntologySecurity.owl#",
-    "dfc-p:hasUnit":{
-      "@type":"@id"
-    },
-    "dfc-b:hasUnit":{
-      "@type":"@id"
-    },
-    "dfc-b:hasQuantity":{
-      "@type":"@id"
-    },
-    "dfc-p:hasType":{
-      "@type":"@id"
-    },
-    "dfc-b:hasType":{
-      "@type":"@id"
-    },
-    "dfc-b:references":{
-      "@type":"@id"
-    },
-    "dfc-b:referencedBy":{
-      "@type":"@id"
-    },
-    "dfc-b:offeres":{
-      "@type":"@id"
-    },
-    "dfc-b:supplies":{
-      "@type":"@id"
-    },
-    "dfc-b:defines":{
-      "@type":"@id"
-    },
-    "dfc-b:affiliates":{
-      "@type":"@id"
-    },
-    "dfc-b:hasCertification":{
-      "@type":"@id"
-    },
-    "dfc-b:manages":{
-      "@type":"@id"
-    },
-    "dfc-b:offeredThrough":{
-      "@type":"@id"
-    },
-    "dfc-b:hasBrand":{
-      "@type":"@id"
-    },
-    "dfc-b:hasGeographicalOrigin":{
-      "@type":"@id"
-    },
-    "dfc-b:hasClaim":{
-      "@type":"@id"
-    },
-    "dfc-b:hasAllergenDimension":{
-      "@type":"@id"
-    },
-    "dfc-b:hasNutrientDimension":{
-      "@type":"@id"
-    },
-    "dfc-b:hasPhysicalDimension":{
-      "@type":"@id"
-    },
-    "dfc:owner":{
-      "@type":"@id"
-    },
-    "dfc-t:hostedBy":{
-      "@type":"@id"
-    },
-    "dfc-t:hasPivot":{
-      "@type":"@id"
-    },
-    "dfc-t:represent":{
-      "@type":"@id"
-    }
-  }
+  "@context": {
+   "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+   "skos" : "http://www.w3.org/2004/02/skos/core#",
+   "dfc": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_FullModel.owl#",
+   "dc": "http://purl.org/dc/elements/1.1/#",
+   "dfc-b": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_BusinessOntology.owl#",
+   "dfc-p": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_ProductGlossary.owl#",
+   "dfc-t": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_TechnicalOntology.owl#",
+   "dfc-m": "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/measures.rdf#",
+   "dfc-pt": "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#",
+   "dfc-f": "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/facets.rdf#",
+  "ontosec": "http://www.semanticweb.org/ontologies/2008/11/OntologySecurity.owl#",
+   "dfc-p:hasUnit":{
+     "@type":"@id"
+   },
+   "dfc-b:hasUnit":{
+     "@type":"@id"
+   },
+   "dfc-b:hasQuantity":{
+     "@type":"@id"
+   },
+   "dfc-p:hasType":{
+     "@type":"@id"
+   },
+   "dfc-b:hasType":{
+     "@type":"@id"
+   },
+   "dfc-b:references":{
+     "@type":"@id"
+   },
+   "dfc-b:referencedBy":{
+     "@type":"@id"
+   },
+   "dfc-b:offers":{
+     "@type":"@id"
+   },
+   "dfc-b:offersTo":{
+     "@type":"@id"
+   },
+   "dfc-b:offeredThrough":{
+     "@type":"@id"
+   },
+   "dfc-b:supplies":{
+     "@type":"@id"
+   },
+   "dfc-b:defines":{
+     "@type":"@id"
+   },
+   "dfc-b:affiliates":{
+     "@type":"@id"
+   },
+   "dfc-b:affiliatedBy":{
+     "@type":"@id"
+   },
+   "dfc-b:orders":{
+     "@type":"@id"
+   },
+   "dfc-b:orderedBy":{
+     "@type":"@id"
+   },
+   "dfc-b:hasPart":{
+     "@type":"@id"
+   },
+   "dfc-b:partOf":{
+     "@type":"@id"
+   },
+   "dfc-b:belongsTo":{
+     "@type":"@id"
+   },
+   "dfc-b:selects":{
+     "@type":"@id"
+   },
+   "dfc-b:concerns":{
+     "@type":"@id"
+   },
+   "dfc-b:uses":{
+     "@type":"@id"
+   },
+   "dfc-b:hasOption":{
+     "@type":"@id"
+   },
+   "dfc-b:hostedAt":{
+     "@type":"@id"
+   },
+   "dfc-b:lists":{
+     "@type":"@id"
+   },
+   "dfc-b:listedIn":{
+     "@type":"@id"
+   },
+   "dfc-b:objectOf":{
+     "@type":"@id"
+   },
+   "dfc-b:hasCertification":{
+     "@type":"@id"
+   },
+   "dfc-b:manages":{
+     "@type":"@id"
+   },
+   "dfc-b:managedBy":{
+     "@type":"@id"
+   },
+   "dfc-b:coordinatedBy":{
+     "@type":"@id"
+   },
+   "dfc-b:hasObject":{
+     "@type":"@id"
+   },
+   "dfc-b:hasBrand":{
+     "@type":"@id"
+   },
+   "dfc-b:hasGeographicalOrigin":{
+     "@type":"@id"
+   },
+   "dfc-b:hasClaim":{
+     "@type":"@id"
+   },
+   "dfc-b:hasAllergenDimension":{
+     "@type":"@id"
+   },
+   "dfc-b:hasNutrientDimension":{
+     "@type":"@id"
+   },
+   "dfc-b:hasPhysicalDimension":{
+     "@type":"@id"
+   },
+   "dfc-b:localizedBy":{
+     "@type":"@id"
+   },
+   "dfc-b:constitutes":{
+     "@type":"@id"
+   },
+   "dfc-b:identifiedBy":{
+     "@type":"@id"
+   },
+   "dfc-b:storedIn":{
+     "@type":"@id"
+   },
+   "dfc:owner":{
+     "@type":"@id"
+   },
+   "dfc-t:hostedBy":{
+     "@type":"@id"
+   },
+   "dfc-t:hasPivot":{
+     "@type":"@id"
+   },
+   "dfc-t:represent":{
+     "@type":"@id"
+   }
+ }
 }


### PR DESCRIPTION
upgrade context.json to match ontology
- replace dfc-b:offeres by dfc-b:offers
- add dfc-b:offersTo as uri predicate
- add dfc-b:affiliatedB as uri predicate
- add dfc-b:orders as uri predicate
- add dfc-b:orderedBy as uri predicate
- add dfc-b:hasPart as uri predicate
- add dfc-b:partOf as uri predicate
- add dfc-b:belongsTo as uri predicate
- add dfc-b:selects as uri predicate
- add dfc-b:concerns as uri predicate
- add dfc-b:uses as uri predicate
- add dfc-b:hasOption as uri predicate
- add dfc-b:hostedAt as uri predicate
- add dfc-b:lists as uri predicate
- add dfc-b:listedIn as uri predicate
- add dfc-b:objectOf as uri predicate
- add dfc-b:managedBy as uri predicate
- add dfc-b:coordinatedBy as uri predicate
- add dfc-b:hasObject as uri predicate
- add dfc-b:localizedBy as uri predicate
- add dfc-b:constitutes as uri predicate
- add dfc-b:identifiedBy as uri predicate
- add dfc-b:storedIn as uri predicate
