### PR TITLE
Auto assign issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
     - name: 'Auto-assign issue'
-      uses: pozil/auto-assign-issue
+      uses: pozil/auto-assign-issue@v2
       with:
           repo-token: ${{ secrets.RAGGEDSTAFF_PAT }}
           teams: ontology-maintainers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Auto Assign
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - name: 'Auto-assign issue'
+      uses: pozil/auto-assign-issue
+      with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          teams: ontology-maintainers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,5 +14,5 @@ jobs:
     - name: 'Auto-assign issue'
       uses: pozil/auto-assign-issue
       with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.RAGGEDSTAFF_PAT }}
           teams: ontology-maintainers


### PR DESCRIPTION
This will create a GitHub action to automatically assign new issues to the @datafoodconsortium/ontology-maintainers team.